### PR TITLE
H, W, and L validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ cron.isValidCron('* * * * 7', { allowSevenAsSunday: true });
 - [x] Support blank day notation with `?` symbol.
 - [x] Support both 0-6 and 1-7 ranges for weekdays.
 - [ ] ~~Have an explain mode returning the fragments in error.~~
-- [ ] Support 'L', 'W' and 'H' usage.
+- [x] Support 'L', 'W' and 'H' usage.
 
 ## Motivations
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -582,4 +582,37 @@ describe('validate', () => {
 
   // TODO: Decide if multiple H in one field should be supported? Would only work properly if their ranges were starting at different points
 
+  it('should not accept L if allowLast is not set', () => {
+    const valid = isValidCron('* * L * *')
+    expect(valid).toBeFalsy()
+
+    const validWithSeconds = isValidCron('* * * L * *', {seconds: true})
+    expect(validWithSeconds).toBeFalsy()
+
+    const validWithAlias = isValidCron('* * L * WED', {alias: true})
+    expect(validWithAlias).toBeFalsy()
+
+    const validWithWrongField = isValidCron('* L * * *')
+    expect(validWithWrongField).toBeFalsy()
+  })
+
+  it('should accept L in DOM and DOW if allowLast is set', () => {
+    const validDOM = isValidCron('* * L * *', {allowLast: true})
+    expect(validDOM).toBeTruthy()
+
+    const validDOMOffset = isValidCron('* * L-2 * *', {allowLast: true})
+    expect(validDOMOffset).toBeTruthy()
+
+    const validDOW = isValidCron('* * * * L', {allowLast: true})
+    expect(validDOW).toBeTruthy()
+
+    const validDOWDay = isValidCron('* * * * 2L', {allowLast: true})
+    expect(validDOWDay).toBeTruthy()
+
+    const validWithWrongField = isValidCron('* L * * *', {allowLast: true})
+    expect(validWithWrongField).toBeFalsy()
+
+    const validWithSeconds = isValidCron('L * * * * *', {allowLast: true, seconds: true})
+    expect(validWithSeconds).toBeFalsy()
+  })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -479,4 +479,90 @@ describe('validate', () => {
     const validWithAliases = isValidCron('* * ? * ?', { alias: true, allowBlankDay: true })
     expect(validWithAliases).toBeFalsy()
   })
+
+  it('should not accept H if allowHashed is not set', () => {
+    const valid = isValidCron('H * * * *')
+    expect(valid).toBeFalsy()
+
+    const validWithSeconds = isValidCron('* * H * * *', {seconds: true} )
+    expect(validWithSeconds).toBeFalsy()
+
+    const validWithAlias = isValidCron('* * H * THU', {alias: true} )
+    expect(validWithAlias).toBeFalsy()
+  })
+
+  it('should accept H if allowHashed is set', () => {
+    const valid = isValidCron('H * * * *', {allowHashed: true})
+    expect(valid).toBeTruthy()
+
+    const validWithSeconds = isValidCron('* * H * * *', {allowHashed: true, seconds: true} )
+    expect(validWithSeconds).toBeTruthy()
+
+    const validWithAlias = isValidCron('* * H * THU', {allowHashed: true, alias: true} )
+    expect(validWithAlias).toBeTruthy()
+  })
+
+  it('should not accept H with ranges if allowHashed is not set', () => {
+    const valid = isValidCron('H(0-20) * * * *')
+    expect(valid).toBeFalsy()
+
+    const validWithSeconds = isValidCron('* * H(10-15) * * *', {seconds: true} )
+    expect(validWithSeconds).toBeFalsy()
+
+    const validWithAlias = isValidCron('* * H(1-8) * THU', {alias: true} )
+    expect(validWithAlias).toBeFalsy()
+  })
+
+  it('should accept H with ranges if allowHashed is set', () => {
+    const valid = isValidCron('H(0-20) * * * *', {allowHashed: true})
+    expect(valid).toBeTruthy()
+
+    const validWithSeconds = isValidCron('* * H(10-15) * * *', {allowHashed: true, seconds: true} )
+    expect(validWithSeconds).toBeTruthy()
+
+    const validWithAlias = isValidCron('* * H(1-8) * THU', {allowHashed: true, alias: true} )
+    expect(validWithAlias).toBeTruthy()
+  })
+
+  it('should not accept H with invalid ranges even if allowHashed is set', () => {
+    const valid = isValidCron('H(0-61) * * * *', {allowHashed: true})
+    expect(valid).toBeFalsy()
+
+    const validWithSeconds = isValidCron('* * H(0-25) * * *', {allowHashed: true, seconds: true} )
+    expect(validWithSeconds).toBeFalsy()
+
+    const validWithAlias = isValidCron('* * H(0-8) * THU', {allowHashed: true, alias: true} )
+    expect(validWithAlias).toBeFalsy()
+
+    const validWithWrongDOM = isValidCron('* * H(1-31) * THU', {allowHashed: true, alias: true} )
+    expect(validWithWrongDOM).toBeFalsy()
+  })
+
+  it('should accept H with iterators if allowHashed is set', () => {
+    const valid = isValidCron('H/8 * * * *', {allowHashed: true})
+    expect(valid).toBeTruthy()
+
+    const validWithSeconds = isValidCron('* * H(10-15)/2 * * *', {allowHashed: true, seconds: true} )
+    expect(validWithSeconds).toBeTruthy()
+
+    const validWithAlias = isValidCron('* * H/4 * THU', {allowHashed: true, alias: true} )
+    expect(validWithAlias).toBeTruthy()
+
+    const validWithWrongIterator = isValidCron('* * H/8 * THU', {allowHashed: true, alias: true} )
+    expect(validWithWrongIterator).toBeFalsy()
+  })
+
+  it('should not accept H in a range if allowHashed is set', () => {
+    const valid = isValidCron('H-8 * * * *', {allowHashed: true})
+    expect(valid).toBeFalsy()
+
+    const validWithSeconds = isValidCron('* * H-2 * * *', {allowHashed: true, seconds: true} )
+    expect(validWithSeconds).toBeFalsy()
+
+    const validWithAlias = isValidCron('* * H-4 * THU', {allowHashed: true, alias: true} )
+    expect(validWithAlias).toBeFalsy()
+  })
+
+  // TODO: Decide if multiple H in one field should be supported? Would only work properly if their ranges were starting at different points
+
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -603,6 +603,12 @@ describe('validate', () => {
     const validDOM = isValidCron('* * L * *', {allowLast: true})
     expect(validDOM).toBeTruthy()
 
+    const validLW = isValidCron('* * LW * *', {allowLast: true, allowWeekday: true})
+    expect(validLW).toBeTruthy()
+
+    const validLWDOW = isValidCron('* * * * LW', {allowLast: true, allowWeekday: true})
+    expect(validLWDOW).toBeFalsy()
+
     const validDOMAlias = isValidCron('* * L * WED', {allowLast: true, alias:true})
     expect(validDOMAlias).toBeTruthy()
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -647,4 +647,51 @@ describe('validate', () => {
     const validDOMDay = isValidCron('* * * 3L * 2L', {allowLast: true, seconds: true})
     expect(validDOMDay).toBeFalsy()
   })
+
+  it('should not accept W if allowWeekdays is not set', () => {
+    const validDOM = isValidCron('* * 1W * *')
+    expect(validDOM).toBeFalsy()
+
+    const validDOW = isValidCron('* * * 5W * *', {seconds: true})
+    expect(validDOW).toBeFalsy()
+
+    const validDOWDay = isValidCron('* * 2W * THU', {alias: true})
+    expect(validDOWDay).toBeFalsy()
+
+    const validDOMDay = isValidCron('* * * 3W * 2L', {allowLast: true, seconds: true})
+    expect(validDOMDay).toBeFalsy()
+  })
+
+  it('should accept W if allowWeekdays is set', () => {
+    const validDOM = isValidCron('* * 1W * *', {allowWeekday: true})
+    expect(validDOM).toBeTruthy()
+
+    const validDOW = isValidCron('* * * 5W * *', {allowWeekday: true, seconds: true})
+    expect(validDOW).toBeTruthy()
+
+    const validDOWDay = isValidCron('* * 2W * THU', {allowWeekday: true, alias: true})
+    expect(validDOWDay).toBeTruthy()
+
+    const validDOMDay = isValidCron('* * * 3W * *', {allowWeekday: true, seconds: true})
+    expect(validDOMDay).toBeTruthy()
+  })
+
+  it('should not accept W in invalid fields or combinations', () => {
+    const validDOM = isValidCron('* * * 1W *', {allowWeekday: true})
+    expect(validDOM).toBeFalsy()
+
+    const validDOW = isValidCron('* * * 32W * *', {allowWeekday: true, seconds: true})
+    expect(validDOW).toBeFalsy()
+
+    const validDOWDay = isValidCron('* * 2W-5 * THU', {allowWeekday: true, alias: true})
+    expect(validDOWDay).toBeFalsy()
+
+    const validDOWDay2 = isValidCron('* * 2-5W * THU', {allowWeekday: true, alias: true})
+    expect(validDOWDay2).toBeFalsy()
+
+    const validDOMDay = isValidCron('* * * * * 2W', {allowWeekday: true, seconds: true})
+    expect(validDOMDay).toBeFalsy()
+  })
+
+  // TODO: L and W usage with iterators?
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -511,6 +511,9 @@ describe('validate', () => {
 
     const validWithAlias = isValidCron('* * H(1-8) * THU', {alias: true} )
     expect(validWithAlias).toBeFalsy()
+
+    const validWithRange = isValidCron('* * H(1-8)-10 * *')
+    expect(validWithRange).toBeFalsy()
   })
 
   it('should accept H with ranges if allowHashed is set', () => {
@@ -522,6 +525,9 @@ describe('validate', () => {
 
     const validWithAlias = isValidCron('* * H(1-8) * THU', {allowHashed: true, alias: true} )
     expect(validWithAlias).toBeTruthy()
+
+    const validWithNoRange = isValidCron('* * H( * THU', {allowHashed: true, alias: true} )
+    expect(validWithNoRange).toBeFalsy()
   })
 
   it('should not accept H with invalid ranges even if allowHashed is set', () => {
@@ -534,8 +540,11 @@ describe('validate', () => {
     const validWithAlias = isValidCron('* * H(0-8) * THU', {allowHashed: true, alias: true} )
     expect(validWithAlias).toBeFalsy()
 
-    const validWithWrongDOM = isValidCron('* * H(1-31) * THU', {allowHashed: true, alias: true} )
+    const validWithWrongDOM = isValidCron('* * H(1-32) * THU', {allowHashed: true, alias: true} )
     expect(validWithWrongDOM).toBeFalsy()
+
+    const validWithRange = isValidCron('H(0-30)-50 * * * *', {allowHashed: true})
+    expect(validWithRange).toBeFalsy()
   })
 
   it('should accept H with iterators if allowHashed is set', () => {
@@ -548,15 +557,16 @@ describe('validate', () => {
     const validWithAlias = isValidCron('* * H/4 * THU', {allowHashed: true, alias: true} )
     expect(validWithAlias).toBeTruthy()
 
-    const validWithWrongIterator = isValidCron('* * H/8 * THU', {allowHashed: true, alias: true} )
-    expect(validWithWrongIterator).toBeFalsy()
+    // TODO: Iterators are always valid if they're integers. Maybe behaviour changes in the future?
+    //const validWithWrongIterator = isValidCron('* * H/32 * THU', {allowHashed: true, alias: true} )
+    //expect(validWithWrongIterator).toBeFalsy()
 
-    // TODO: Allow H as a step val?
+    // TODO: Allow H as a step val? No.
     const validWithHstep = isValidCron('* * 4/H * *', {allowHashed: true} )
-    expect(validWithHstep).toBeTruthy()
+    expect(validWithHstep).toBeFalsy()
 
     const validWithHstep2 = isValidCron('* * 4/H(1-5) * *', {allowHashed: true} )
-    expect(validWithHstep2).toBeTruthy()
+    expect(validWithHstep2).toBeFalsy()
   })
 
   it('should not accept H in a range if allowHashed is set', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -603,6 +603,12 @@ describe('validate', () => {
     const validDOM = isValidCron('* * L * *', {allowLast: true})
     expect(validDOM).toBeTruthy()
 
+    const validDOMAlias = isValidCron('* * L * WED', {allowLast: true, alias:true})
+    expect(validDOMAlias).toBeTruthy()
+
+    const validDOMsec = isValidCron('* * * L * THU', {allowLast: true, alias: true, seconds: true})
+    expect(validDOMsec).toBeTruthy()
+
     const validDOMOffset = isValidCron('* * L-2 * *', {allowLast: true})
     expect(validDOMOffset).toBeTruthy()
 
@@ -617,5 +623,22 @@ describe('validate', () => {
 
     const validWithSeconds = isValidCron('L * * * * *', {allowLast: true, seconds: true})
     expect(validWithSeconds).toBeFalsy()
+  })
+
+  it('should not accept L in invalid places or with invalid offsets/values', () => {
+    const validDOM = isValidCron('* L L * *', {allowLast: true})
+    expect(validDOM).toBeFalsy()
+
+    const validDOMOffset = isValidCron('* L-2 L-3 * *', {allowLast: true})
+    expect(validDOMOffset).toBeFalsy()
+
+    const validDOW = isValidCron('* * * * L *', {allowLast: true, seconds: true})
+    expect(validDOW).toBeFalsy()
+
+    const validDOWDay = isValidCron('* * * * 2L-2', {allowLast: true})
+    expect(validDOWDay).toBeFalsy()
+
+    const validDOMDay = isValidCron('* * * 3L * 2L', {allowLast: true, seconds: true})
+    expect(validDOMDay).toBeFalsy()
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -545,6 +545,9 @@ describe('validate', () => {
 
     const validWithRange = isValidCron('H(0-30)-50 * * * *', {allowHashed: true})
     expect(validWithRange).toBeFalsy()
+
+    const validWithReverse = isValidCron('H(30-0) * * * *', {allowHashed: true})
+    expect(validWithReverse).toBeFalsy()
   })
 
   it('should accept H with iterators if allowHashed is set', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -550,6 +550,13 @@ describe('validate', () => {
 
     const validWithWrongIterator = isValidCron('* * H/8 * THU', {allowHashed: true, alias: true} )
     expect(validWithWrongIterator).toBeFalsy()
+
+    // TODO: Allow H as a step val?
+    const validWithHstep = isValidCron('* * 4/H * *', {allowHashed: true} )
+    expect(validWithHstep).toBeTruthy()
+
+    const validWithHstep2 = isValidCron('* * 4/H(1-5) * *', {allowHashed: true} )
+    expect(validWithHstep2).toBeTruthy()
   })
 
   it('should not accept H in a range if allowHashed is set', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,7 @@ type Options = {
   allowBlankDay: boolean
   allowSevenAsSunday: boolean
   allowHashed: boolean
+  allowLast: boolean
 }
 
 const defaultOptions: Options = {
@@ -180,7 +181,8 @@ const defaultOptions: Options = {
   seconds: false,
   allowBlankDay: false,
   allowSevenAsSunday: false,
-  allowHashed: false
+  allowHashed: false,
+  allowLast: false
 }
 
 export const isValidCron = (cron: string, options?: Partial<Options>): boolean => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,13 @@ const isValidLast = (value: string[], start: number, stop: number, allowWeekday:
   }
 }
 
+const isValidWeekday = (value: string[], start: number, stop: number): boolean => {
+  if (value.length === 1) {
+    return value[0].slice(-1) === "W" && isInRange( safeParseInt(value[0].slice(0,-1)), start, stop )
+  }
+  return false
+}
+
 const isValidRange = (value: string, start: number, stop: number, allowHashed?: boolean, allowLast?: boolean, allowWeekday?: boolean, inWeekday?: boolean): boolean => {
   const sides = value.split('-')
   if (allowHashed && sides[0].slice(0,1) === "H") {
@@ -54,7 +61,7 @@ const isValidRange = (value: string, start: number, stop: number, allowHashed?: 
   }
   switch (sides.length) {
     case 1:
-      return isWildcard(value) || isInRange(safeParseInt(value), start, stop) || (!!allowLast && isValidLast(sides, start, stop, !!allowWeekday, !!inWeekday))
+      return isWildcard(value) || isInRange(safeParseInt(value), start, stop) || (!!allowLast && isValidLast(sides, start, stop, !!allowWeekday, !!inWeekday)) || (!!allowWeekday && isValidWeekday(sides, start, stop))
     case 2:
       const [small, big] = sides.map((side: string): number => safeParseInt(side))
       return (small <= big && isInRange(small, start, stop) && isInRange(big, start, stop)) || (!!allowLast && isValidLast(sides, start, stop, !!allowWeekday, !!inWeekday))

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,23 @@ const isInRange = (value: number, start: number, stop: number): boolean => {
   return value >= start && value <= stop
 }
 
-const isValidRange = (value: string, start: number, stop: number): boolean => {
+const isValidHashed = (value: string[], start: number, stop: number): boolean => {
+  switch (value.length) {
+    case 1:
+      return value[0] === "H"
+    case 2:
+      // H Range: Has to start with H(, integers in range need to be valid, end has to be /\d\)/
+      return value[0].slice(0,2) === "H(" && isInRange(safeParseInt( value[0].slice(2) ), start, stop) && isInRange(safeParseInt(value[1].slice(0,-1)), start, stop) && value[1].search(/\d+\)/) === 0
+    default:
+      return false
+  }
+}
+
+const isValidRange = (value: string, start: number, stop: number, allowHashed?: boolean): boolean => {
   const sides = value.split('-')
+  if (allowHashed && sides[0].slice(0,1) === "H") {
+    return isValidHashed(sides, start, stop)
+  }
   switch (sides.length) {
     case 1:
       return isWildcard(value) || isInRange(safeParseInt(value), start, stop)
@@ -37,8 +52,8 @@ const isValidStep = (value: string | undefined): boolean => {
   return value === undefined || (value.search(/[^\d]/) === -1 && safeParseInt(value) > 0)
 }
 
-const validateForRange = (value: string, start: number, stop: number): boolean => {
-  if (value.search(/[^\d-,\/*]/) !== -1) {
+const validateForRange = (value: string, start: number, stop: number, allowHashed?: boolean): boolean => {
+  if (value.search(/[^\d-,\/*H()]/) !== -1) {
     return false
   }
 
@@ -57,24 +72,24 @@ const validateForRange = (value: string, start: number, stop: number): boolean =
 
     // If we don't have a `/`, right will be undefined which is considered a valid step if we don't a `/`.
     const [left, right] = splits
-    return isValidRange(left, start, stop) && isValidStep(right)
+    return isValidRange(left, start, stop, allowHashed) && isValidStep(right)
   })
 }
 
-const hasValidSeconds = (seconds: string): boolean => {
-  return validateForRange(seconds, 0, 59)
+const hasValidSeconds = (seconds: string, allowHashed?: boolean): boolean => {
+  return validateForRange(seconds, 0, 59, allowHashed)
 }
 
-const hasValidMinutes = (minutes: string): boolean => {
-  return validateForRange(minutes, 0, 59)
+const hasValidMinutes = (minutes: string, allowHashed?: boolean): boolean => {
+  return validateForRange(minutes, 0, 59, allowHashed)
 }
 
-const hasValidHours = (hours: string): boolean => {
-  return validateForRange(hours, 0, 23)
+const hasValidHours = (hours: string, allowHashed?: boolean): boolean => {
+  return validateForRange(hours, 0, 23, allowHashed)
 }
 
-const hasValidDays = (days: string, allowBlankDay?: boolean): boolean => {
-  return (allowBlankDay && isQuestionMark(days)) || validateForRange(days, 1, 31)
+const hasValidDays = (days: string, allowBlankDay?: boolean, allowHashed?: boolean): boolean => {
+  return (allowBlankDay && isQuestionMark(days)) || validateForRange(days, 1, 31, allowHashed)
 }
 
 const monthAlias: { [key: string]: string } = {
@@ -92,7 +107,7 @@ const monthAlias: { [key: string]: string } = {
   dec: '12'
 }
 
-const hasValidMonths = (months: string, alias?: boolean): boolean => {
+const hasValidMonths = (months: string, alias?: boolean, allowHashed?: boolean): boolean => {
   // Prevents alias to be used as steps
   if (months.search(/\/[a-zA-Z]/) !== -1) {
     return false
@@ -103,10 +118,10 @@ const hasValidMonths = (months: string, alias?: boolean): boolean => {
       return monthAlias[match] === undefined ? match : monthAlias[match]
     })
     // If any invalid alias was used, it won't pass the other checks as there will be non-numeric values in the months
-    return validateForRange(remappedMonths, 1, 12)
+    return validateForRange(remappedMonths, 1, 12, allowHashed)
   }
 
-  return validateForRange(months, 1, 12)
+  return validateForRange(months, 1, 12, allowHashed)
 }
 
 const weekdaysAlias: { [key: string]: string } = {
@@ -119,7 +134,7 @@ const weekdaysAlias: { [key: string]: string } = {
   sat: '6'
 }
 
-const hasValidWeekdays = (weekdays: string, alias?: boolean, allowBlankDay?: boolean, allowSevenAsSunday?: boolean): boolean => {
+const hasValidWeekdays = (weekdays: string, alias?: boolean, allowBlankDay?: boolean, allowSevenAsSunday?: boolean, allowHashed?: boolean): boolean => {
 
   // If there is a question mark, checks if the allowBlankDay flag is set
   if (allowBlankDay && isQuestionMark(weekdays)) {
@@ -138,10 +153,10 @@ const hasValidWeekdays = (weekdays: string, alias?: boolean, allowBlankDay?: boo
       return weekdaysAlias[match] === undefined ? match : weekdaysAlias[match]
     })
     // If any invalid alias was used, it won't pass the other checks as there will be non-numeric values in the weekdays
-    return validateForRange(remappedWeekdays, 0, allowSevenAsSunday ? 7 : 6)
+    return validateForRange(remappedWeekdays, 0, allowSevenAsSunday ? 7 : 6, allowHashed)
   }
 
-  return validateForRange(weekdays, 0, allowSevenAsSunday ? 7 : 6)
+  return validateForRange(weekdays, 0, allowSevenAsSunday ? 7 : 6, allowHashed)
 }
 
 const hasCompatibleDayFormat = (days: string, weekdays: string, allowBlankDay?: boolean) => {
@@ -157,13 +172,15 @@ type Options = {
   seconds: boolean
   allowBlankDay: boolean
   allowSevenAsSunday: boolean
+  allowHashed: boolean
 }
 
 const defaultOptions: Options = {
   alias: false,
   seconds: false,
   allowBlankDay: false,
-  allowSevenAsSunday: false
+  allowSevenAsSunday: false,
+  allowHashed: false
 }
 
 export const isValidCron = (cron: string, options?: Partial<Options>): boolean => {
@@ -179,18 +196,18 @@ export const isValidCron = (cron: string, options?: Partial<Options>): boolean =
   if (splits.length === 6) {
     const seconds = splits.shift()
     if (seconds) {
-      checks.push(hasValidSeconds(seconds))
+      checks.push(hasValidSeconds(seconds, options.allowHashed))
     }
   }
 
   // We could only check the steps gradually and return false on the first invalid block,
   // However, this won't have any performance impact so why bother for now.
   const [minutes, hours, days, months, weekdays] = splits
-  checks.push(hasValidMinutes(minutes))
-  checks.push(hasValidHours(hours))
-  checks.push(hasValidDays(days, options.allowBlankDay))
-  checks.push(hasValidMonths(months, options.alias))
-  checks.push(hasValidWeekdays(weekdays, options.alias, options.allowBlankDay, options.allowSevenAsSunday))
+  checks.push(hasValidMinutes(minutes, options.allowHashed))
+  checks.push(hasValidHours(hours, options.allowHashed))
+  checks.push(hasValidDays(days, options.allowBlankDay, options.allowHashed))
+  checks.push(hasValidMonths(months, options.alias, options.allowHashed))
+  checks.push(hasValidWeekdays(weekdays, options.alias, options.allowBlankDay, options.allowSevenAsSunday, options.allowHashed))
   checks.push(hasCompatibleDayFormat(days, weekdays, options.allowBlankDay))
 
   return checks.every(Boolean)

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,9 @@ const isValidHashed = (value: string[], start: number, stop: number): boolean =>
       return value[0] === "H"
     case 2:
       // H Range: Has to start with H(, integers in range need to be valid, end has to be /\d\)/
-      return value[0].slice(0,2) === "H(" && isInRange(safeParseInt( value[0].slice(2) ), start, stop) && isInRange(safeParseInt(value[1].slice(0,-1)), start, stop) && value[1].search(/\d+\)/) === 0
+      const startNum = safeParseInt(value[0].slice(2))
+      const stopNum = safeParseInt(value[1].slice(0,-1))
+      return value[0].slice(0,2) === "H(" && startNum <= stopNum && isInRange(startNum, start, stop) && isInRange(stopNum, start, stop) && value[1].search(/\d+\)/) === 0
     default:
       return false
   }


### PR DESCRIPTION
Allows validation of CRONs using H, W and L in cron-validator:

- H will be a pseudo-random number for a field, linked to the project name or something similar. It allows easier load balancing. See [Jenkins doc](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.jelly)
- W can be written after a day of month to ensure the CRON is executed on the closest working week day (Mon-Fri).
- L can either mean the last day of month/day of week, or _x_ days before that if used with an offset (L-_x_), or the last working week day of a month if used with W (LW).